### PR TITLE
Label mpijobs with the notebook that dispatched them.

### DIFF
--- a/mpi-job-files/MPIJobTemplate.yaml
+++ b/mpi-job-files/MPIJobTemplate.yaml
@@ -3,6 +3,8 @@ kind: MPIJob
 metadata:
   name: #<mpiJobName>
   namespace: openmpp-uat
+  labels:
+    notebook-name: #<notebookName>
 spec:
   #slotsPerWorker: Tensorflow example sets this attribute, but Pat's example template doesn't.
   runPolicy:

--- a/mpi-job-files/parseCommand.py
+++ b/mpi-job-files/parseCommand.py
@@ -19,10 +19,16 @@ with open("./etc/MPIJobTemplate.yaml") as template:
 with open("./etc/inputArguments", "w") as inputArgs:
   inputArgs.write(' '.join(sys.argv))
  
+with open("/etc/hostname") as nN:
+  notebookName = nN.read()
+
 # Save unrecognized command line options to file for debugging:
 unrecognized = ""
 
 # Some manifest values are based on system configuration:
+# Set notebook name label so we can filter mpijobs by label for deletion:
+manifest = manifest.replace("#<notebookName>", notebookName)
+
 # Set working directory for mpirun to the ...models/bin directory:
 manifest = manifest.replace("#<mpirunOption>", \
   f"- -wdir\n{12*' '}- {modelBinsDir}\n{12*' '}#<mpirunOption>")


### PR DESCRIPTION
We want to filter mpijobs based on which notebook dispatched them so that we can delete mpijobs from rounds of testing from other users' jobs.