### PR TITLE
Check Model MPI exe exists and better error message

### DIFF
--- a/mpi-job-files/dispatchMPIJob.sh
+++ b/mpi-job-files/dispatchMPIJob.sh
@@ -5,6 +5,13 @@
 # Parse openm web service arguments and create manifest instance:
 manifest=$(python3 ./bin/parseCommand.py "$@")
 
+# KLW 16-01-2024 https://github.com/StatCan/openmpp/issues/51
+if [[ -z $manifest ]]; then
+  echo "ERROR: path to MPI model executable does not exist"
+  echo "Did you compile it?"
+  exit 1
+fi
+
 # Create a copy of manifest for trouble-shooting:
 echo "$manifest" > "./etc/MPIJob-$ManifestInstance.yaml"
 

--- a/mpi-job-files/parseCommand.py
+++ b/mpi-job-files/parseCommand.py
@@ -44,6 +44,10 @@ while i < len(sys.argv):
     # Construct fully qualified model executable name:
     modelExecutable = '_'.join([os.path.join(modelBinsDir, sys.argv[i+1]), "mpi"])
 
+    # KLW 16-01-2024 https://github.com/StatCan/openmpp/issues/51
+    if not os.path.isfile(modelExecutable):
+        exit()
+      
     # Enter unique mpijob name:
     mpiJobName = f"{sys.argv[i+1]}-{str(time()).replace('.', '-')}".lower()
     manifest = manifest.replace("#<mpiJobName>", mpiJobName)


### PR DESCRIPTION
As part of https://github.com/StatCan/openmpp/issues/51, a check was added to confirm that the Model MPI executable exists before launching the MPI Job and a more informative error message was added.