### PR TITLE
60 bug ini file binding

### DIFF
--- a/mpi-job-files/parseCommand.py
+++ b/mpi-job-files/parseCommand.py
@@ -89,7 +89,7 @@ while i < len(sys.argv):
       i += 2
     else:
       openmOptions.append(sys.argv[i])
-      openmOptions.append("false")
+      openmOptions.append("true") #KLW 2024-02-06 OpenM docs say this value should be 'true'
       i += 1
 
   # ini options and arguments:

--- a/mpi-job-files/parseCommand.py
+++ b/mpi-job-files/parseCommand.py
@@ -82,7 +82,7 @@ while i < len(sys.argv):
   # KLW 2024-02-06  https://github.com/StatCan/openmpp/issues/60
   # There is a bug in OpenM in regard to the -OpenM.NotOnRoot argument.  
   # The Value is suppose to be true or false, but is missing when false
-  elif (i + 1 < len(sys.argv) and re.match("^-OpenM.NotOnRoot$", sys.argv[i]):
+  elif (i + 1 < len(sys.argv) and re.match("^-OpenM.NotOnRoot$", sys.argv[i])):
     if (re.match("^true$", sys.argv[i+1]) or re.match("^false$", sys.argv[i+1]) ):
       openmOptions.append(sys.argv[i])
       openmOptions.append(sys.argv[i+1])

--- a/mpi-job-files/parseCommand.py
+++ b/mpi-job-files/parseCommand.py
@@ -78,6 +78,29 @@ while i < len(sys.argv):
       f"- -x\n{12*' '}- {sys.argv[i+1]}\n{12*' '}#<mpirunOption>")
     i += 2
 
+  # OpenM options and arguments exception:
+  # KLW 2024-02-06  https://github.com/StatCan/openmpp/issues/60
+  # There is a bug in OpenM in regard to the -OpenM.NotOnRoot argument.  
+  # The Value is suppose to be true or false, but is missing when false
+  elif (i + 1 < len(sys.argv) and re.match("^-OpenM.NotOnRoot$", sys.argv[i]):
+    if (re.match("^true$", sys.argv[i+1]) or re.match("^false$", sys.argv[i+1]) ):
+      openmOptions.append(sys.argv[i])
+      openmOptions.append(sys.argv[i+1])
+      i += 2
+    else:
+      openmOptions.append(sys.argv[i])
+      openmOptions.append("false")
+      i += 1
+
+  # ini options and arguments:
+  # KLW 2024-02-06 Explicit handling of the -ini argument
+  elif (i + 1 < len(sys.argv) and re.match("^-ini$", sys.argv[i]) \
+  and re.match("[a-zA-Z0-9_/\.-]+", sys.argv[i+1])):
+    openmOptions.append(sys.argv[i])
+    openmOptions.append(sys.argv[i+1])
+    i += 2
+    
+  
   # OpenM options and arguments:
   elif (i + 1 < len(sys.argv) and re.match("^-OpenM\.", sys.argv[i]) \
   and re.match("[a-zA-Z0-9_/\.-]+", sys.argv[i+1])):


### PR DESCRIPTION
INI file is now passed though the parseCommand.py script.
There were multiple issues, including the -ini argument being dropped because it wasn't recognized and a work-around for the -OpenM.NotOnRoot argument issue.  Issue [#56](https://github.com/StatCan/openmpp/issues/56).  The parseCommand script assumes that all arguments beginning with -OpenM. have a value but the NotOnRoot argument does not.  This picked up the -ini argument flag as the value for NotOnRoot because it followed it.  The value for the -ini argument was put into the unrecognizedCmdLineOptions file because it was unmatched.

Fix:
- The -OpenM.NotOnRoot argument is correctly parsed even if it has no value, and it the value does not exist, a default value of false is added.
- The -ini argument is correctly parsed and outputted into the Manifest File.