### PR TITLE
chore(mpi): scale up workers for better perf

### DIFF
--- a/mpi-job-files/MPIJobTemplate.yaml
+++ b/mpi-job-files/MPIJobTemplate.yaml
@@ -51,11 +51,11 @@ spec:
             name: #<mpiJobName>-worker
             resources:
                 limits:
-                  cpu: '2'
-                  memory: 2Gi
+                  cpu: '5'
+                  memory: 5Gi
                 requests:
-                  cpu: '2'
-                  memory: 1Gi
+                  cpu: '4'
+                  memory: 4Gi
             volumeMounts:
             - mountPath: /home/jovyan/mpi-test
               name: mpi-test


### PR DESCRIPTION
Oncosim model runs can peak well over 1gb of memory. Scaling up should allow better compute efficiency.